### PR TITLE
Straitjacket.Math 0.1

### DIFF
--- a/Straitjacket.MathModule/Properties/AssemblyInfo.cs
+++ b/Straitjacket.MathModule/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.1.0")]
-[assembly: AssemblyFileVersion("0.0.1.0")]
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]


### PR DESCRIPTION
# Changes in this version
- Compiled binary now targets .NET Framework 3.5 and UnityEngine 5 to increase project support. #6  